### PR TITLE
Pull user timezone in middleware.

### DIFF
--- a/timetracker/account/middleware.py
+++ b/timetracker/account/middleware.py
@@ -27,6 +27,10 @@ class TimezoneMiddleware:
         """
         tz = request.session.get('django_timezone', None)
 
+        if tz is None and request.user.is_authenticated:
+            tz = request.user.timezone
+            request.session['django_timezone'] = tz
+
         if tz:
             try:
                 timezone.activate(tz)

--- a/timetracker/account/test/middleware/test_timezone_middleware.py
+++ b/timetracker/account/test/middleware/test_timezone_middleware.py
@@ -1,0 +1,126 @@
+from unittest import mock
+
+import pytest
+import pytz
+from django.contrib.auth.models import AnonymousUser
+
+from account import middleware
+
+
+@pytest.fixture
+def middleware_instance() -> middleware.TimezoneMiddleware:
+    """
+    Fixture to get an instance of the ``TimezoneMiddleware`` class.
+    """
+    get_response = mock.MagicMock(name='Mock get_response')
+
+    return middleware.TimezoneMiddleware(get_response)
+
+
+@pytest.fixture
+def middleware_request(request_factory):
+    """
+    Return a generic request that can be used to test middleware.
+    """
+    request = request_factory.get('/')
+    request.session = {}
+    request.user = AnonymousUser()
+
+    return request
+
+
+@pytest.fixture
+def mock_timezone():
+    """
+    Fixture to get a mock version of Django's timezone utilities.
+    """
+    with mock.patch(
+        'account.middleware.timezone',
+        autospec=True,
+    ) as mock_timezone:
+        yield mock_timezone
+
+
+def test_no_timezone_anonymous_user(
+        middleware_instance,
+        middleware_request,
+        mock_timezone):
+    """
+    If there is no timezone in the current session and the current user
+    is anonymous, timezone support should be deactivated.
+    """
+    middleware_instance(middleware_request)
+
+    assert mock_timezone.deactivate.call_count == 1
+    assert middleware_instance.get_response.call_count == 1
+    assert middleware_instance.get_response.call_args[0] == (
+        middleware_request,
+    )
+
+
+def test_no_timezone_authenticated_user(
+        middleware_instance,
+        middleware_request,
+        mock_timezone,
+        user_factory):
+    """
+    If there is no timezone in the session but the user is
+    authenticated, the user's timezone should be used and set in the
+    session.
+    """
+    user = user_factory()
+    middleware_request.user = user
+
+    middleware_instance(middleware_request)
+
+    assert mock_timezone.activate.call_args[0] == (user.timezone,)
+    assert middleware_request.session['django_timezone'] == user.timezone
+    assert middleware_instance.get_response.call_count == 1
+    assert middleware_instance.get_response.call_args[0] == (
+        middleware_request,
+    )
+
+
+def test_timezone_invalid(
+        middleware_instance,
+        middleware_request,
+        mock_timezone):
+    """
+    If the timezone set in the session is invalid, timezone support
+    should be disabled.
+    """
+    mock_timezone.activate = mock.MagicMock(
+        side_effect=pytz.UnknownTimeZoneError,
+    )
+
+    middleware_request.session['django_timezone'] = 'foo'
+
+    middleware_instance(middleware_request)
+
+    assert mock_timezone.deactivate.call_count == 1
+    assert middleware_instance.get_response.call_count == 1
+    assert middleware_instance.get_response.call_args[0] == (
+        middleware_request,
+    )
+
+
+def test_timezone_valid(
+        middleware_instance,
+        middleware_request,
+        mock_timezone):
+    """
+    If the request session has a valid timezone set, that timezone
+    should be activated.
+    """
+    middleware_request.session['django_timezone'] = 'America/New_York'
+
+    middleware_instance(middleware_request)
+
+    assert mock_timezone.activate.call_count == 1
+    assert mock_timezone.activate.call_args[0] == (
+        middleware_request.session['django_timezone'],
+    )
+    assert middleware_instance.get_response.call_count == 1
+    assert middleware_instance.get_response.call_args[0] == (
+        middleware_request,
+    )

--- a/timetracker/conftest.py
+++ b/timetracker/conftest.py
@@ -1,6 +1,7 @@
 import factory
 import pytest
 from django.conf import settings
+from django.test import RequestFactory
 
 
 class UserFactory(factory.django.DjangoModelFactory):
@@ -20,6 +21,14 @@ class UserFactory(factory.django.DjangoModelFactory):
         manager = cls._get_manager(model_class)
 
         return manager.create_user(*args, **kwargs)
+
+
+@pytest.fixture
+def request_factory() -> RequestFactory:
+    """
+    Get a factory used to generate test requests.
+    """
+    return RequestFactory()
 
 
 @pytest.fixture


### PR DESCRIPTION
If the timezone is not set in the current session and the user is authenticated, we pull timezone information from the authenticated user.