### PR TITLE
Generate slugs for client jobs.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,6 @@ ipython = "*"
 pytest = "*"
 pytest-django = "*"
 factory-boy = "*"
-pipenv = "*"
 codecov = "*"
 coverage = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "09e84b98200c5d5be1fdac365e394b59208a7103979dc3a6f458a8ecb7863109"
+            "sha256": "fc8f2361ca4ff0e35ed0e167aa804c194020a42e0ee84e4a5e263f27abb4a334"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -124,6 +124,7 @@
             "hashes": [
                 "sha256:03481e81d558d30d230bc12999e3edffe392d244349a90f4ef9b88425fac74ba",
                 "sha256:0b136648de27201056c1869a6c0d4e23f464750fd9a9ba9750b8336a244429ed",
+                "sha256:0bf8cbbd71adfff0ef1f3a1531e6402d13b7b01ac50a79c97ca15f030dba6306",
                 "sha256:10a46017fef60e16694a30627319f38a2b9b52e90182dddb6e37dcdab0f4bf95",
                 "sha256:198626739a79b09fa0a2f06e083ffd12eb55449b5f8bfdbeed1df4910b2ca640",
                 "sha256:23d341cdd4a0371820eb2b0bd6b88f5003a7438bbedb33688cd33b8eae59affd",
@@ -152,6 +153,7 @@
                 "sha256:c1bb572fab8208c400adaf06a8133ac0712179a334c09224fb11393e920abcdd",
                 "sha256:de4418dadaa1c01d497e539210cb6baa015965526ff5afc078c57ca69160108d",
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
+                "sha256:f05a636b4564104120111800021a92e43397bc12a5c72fed7036be8556e0029e",
                 "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
             ],
             "index": "pypi",
@@ -253,15 +255,6 @@
             ],
             "version": "==0.7.5"
         },
-        "pipenv": {
-            "hashes": [
-                "sha256:a785235bf2ddf65ea8a91531b3372471d9ad86036335dba8bd63f20c00a68e63",
-                "sha256:aca036e5fe988c8c2850167976b9361cfa8519afffe95bb1010105547622f9ee",
-                "sha256:d5ac9a7705c654ec6ed0059df4f0470d88119591d2724828cb5268207547afc1"
-            ],
-            "index": "pypi",
-            "version": "==2018.10.13"
-        },
         "pluggy": {
             "hashes": [
                 "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
@@ -314,11 +307,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:10e59f84267370ab20cec9305bafe7505ba4d6b93ecbf66a1cce86193ed511d5",
-                "sha256:8c827e7d4816dfe13e9329c8226aef8e6e75d65b939bc74fda894143b6d1df59"
+                "sha256:212be78a6fa5352c392738a49b18f74ae9aeec1040f47c81cadbfd8d1233c310",
+                "sha256:6f6c1efc8d0ccc21f8f6c34d8330baca883cf109b66b3df954b0a117e5528fb4"
             ],
             "index": "pypi",
-            "version": "==3.9.1"
+            "version": "==3.9.2"
         },
         "pytest-django": {
             "hashes": [
@@ -375,19 +368,6 @@
                 "sha256:8819bba37a02d143296a4d032373c4dd4aca11f6d4c9973335ca75f9c8475f59"
             ],
             "version": "==1.24"
-        },
-        "virtualenv": {
-            "hashes": [
-                "sha256:2ce32cd126117ce2c539f0134eb89de91a8413a29baac49cbab3eb50e2026669",
-                "sha256:ca07b4c0b54e14a91af9f34d0919790b016923d157afda5efdde55c96718f752"
-            ],
-            "version": "==16.0.0"
-        },
-        "virtualenv-clone": {
-            "hashes": [
-                "sha256:afce268508aa5596c90dda234abe345deebc401a57d287bcbd76baa140a1aa58"
-            ],
-            "version": "==0.4.0"
         },
         "wcwidth": {
             "hashes": [

--- a/timetracker/vms/test/conftest.py
+++ b/timetracker/vms/test/conftest.py
@@ -36,6 +36,15 @@ class ClientJobFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = 'vms.ClientJob'
 
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        model = super()._create(model_class, *args, **kwargs)
+
+        model.clean()
+        model.save()
+
+        return model
+
 
 class EmployeeFactory(factory.django.DjangoModelFactory):
     """

--- a/timetracker/vms/test/models/test_client_job_model.py
+++ b/timetracker/vms/test/models/test_client_job_model.py
@@ -1,3 +1,83 @@
+import pytest
+from django.core.exceptions import ValidationError
+from django.utils.text import slugify
+
+from vms import models
+
+
+def test_clean_new(client_factory):
+    """
+    Cleaning a new client job should generate a slug for the job.
+    """
+    job = models.ClientJob(
+        client=client_factory(),
+        name='Job Title',
+        pay_rate=42,
+    )
+    job.clean()
+
+    assert job.slug == slugify(job.name)
+
+
+def test_clean_old(client_job_factory):
+    """
+    Cleaning an existing client job with a new name should not update
+    the slug.
+    """
+    job = client_job_factory(name='Old Job Name')
+    slug = job.slug
+
+    job.name = 'New Job Name'
+    job.clean()
+
+    assert job.slug == slug
+
+
+def test_clean_fields_duplicate_name(client_job_factory):
+    """
+    If a job will slugify to the same value as an existing job for the
+    same client, the validation should fail.
+    """
+    old_job = client_job_factory()
+    new_job = models.ClientJob(
+        client=old_job.client,
+        name=old_job.name,
+        pay_rate=42,
+    )
+    new_job.clean()
+
+    with pytest.raises(ValidationError):
+        new_job.clean_fields()
+
+
+def test_clean_fields_excluded(client_job_factory):
+    """
+    If the job is a duplicate but the name field is excluded, validation
+    should pass.
+    """
+    old_job = client_job_factory()
+    new_job = models.ClientJob(
+        client=old_job.client,
+        name=old_job.name,
+        pay_rate=42,
+    )
+
+    new_job.clean()
+    new_job.clean_fields(exclude=['name'])
+
+
+def test_clean_fields_same_slug_different_client(client_job_factory):
+    """
+    If two jobs have the same slug but belong to different clients, the
+    validation should pass.
+    """
+    job1 = client_job_factory(name='Common Name')
+    job2 = client_job_factory(name='Common Name')
+
+    job1.clean_fields()
+    job2.clean_fields()
+
+
 def test_string_conversion(client_job_factory):
     """
     Converting a client job to a string should return the name of the


### PR DESCRIPTION
When creating a `ClientJob` instance, a slug is now generated for the job and validated to ensure it is not too similar to another job for the same client.

Closes #28 