### PR TITLE
Modify time tracking URLs to use slugs.

### DIFF
--- a/timetracker/vms/models.py
+++ b/timetracker/vms/models.py
@@ -5,6 +5,7 @@ import uuid
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from django.utils.text import slugify
@@ -336,6 +337,34 @@ class Employee(models.Model):
             employee instance.
         """
         return f'{self.user.name} (Hired by {self.staffing_agency})'
+
+    @property
+    def clock_in_url(self):
+        """
+        Returns:
+            The absolute URL of the view used to clock in the employee.
+        """
+        return reverse(
+            'vms:clock-in',
+            kwargs={
+                'client_slug': self.supervisor.client.slug,
+                'employee_id': self.employee_id,
+            },
+        )
+
+    @property
+    def clock_out_url(self):
+        """
+        Returns:
+            The absolute URL of the view used to clock out the employee.
+        """
+        return reverse(
+            'vms:clock-out',
+            kwargs={
+                'client_slug': self.supervisor.client.slug,
+                'employee_id': self.employee_id,
+            },
+        )
 
     @property
     def is_clocked_in(self):

--- a/timetracker/vms/templates/vms/dashboard.html
+++ b/timetracker/vms/templates/vms/dashboard.html
@@ -6,9 +6,9 @@
   <h2>Quick Links</h2>
   {% for employee in employees %}
     {% if employee.is_clocked_in %}
-      <a href="{% url 'vms:clock-out' employee.id %}">Clock Out {{ employee }}</a>
+      <a href="{{ employee.clock_out_url }}">Clock Out {{ employee }}</a>
     {% else %}
-      <a href="{% url 'vms:clock-in' employee.id %}">Clock In {{ employee }}</a>
+      <a href="{{ employee.clock_in_url }}">Clock In {{ employee }}</a>
     {% endif %}
   {% endfor %}
 

--- a/timetracker/vms/test/models/test_employee_model.py
+++ b/timetracker/vms/test/models/test_employee_model.py
@@ -1,7 +1,42 @@
 import pytest
 from django.core.exceptions import ValidationError
+from django.urls import reverse
 
 from vms import models
+
+
+def test_clock_in_url(employee_factory):
+    """
+    This property should return the URL of the view used to clock in an
+    employee.
+    """
+    employee = employee_factory()
+    expected = reverse(
+        'vms:clock-in',
+        kwargs={
+            'client_slug': employee.supervisor.client.slug,
+            'employee_id': employee.employee_id,
+        },
+    )
+
+    assert employee.clock_in_url == expected
+
+
+def test_clock_out_url(employee_factory):
+    """
+    This property should return the URL of the view used to clock out an
+    employee.
+    """
+    employee = employee_factory()
+    expected = reverse(
+        'vms:clock-out',
+        kwargs={
+            'client_slug': employee.supervisor.client.slug,
+            'employee_id': employee.employee_id,
+        },
+    )
+
+    assert employee.clock_out_url == expected
 
 
 def test_save_new_employee(

--- a/timetracker/vms/urls.py
+++ b/timetracker/vms/urls.py
@@ -1,11 +1,12 @@
-from django.urls import path
+from django.urls import include, path
 
 from vms import views
 
 
 app_name = 'vms'
 
-urlpatterns = [
+
+client_detail_urls = [
     path(
         'employees/<int:employee_id>/clock-in/',
         views.ClockInView.as_view(),
@@ -15,6 +16,14 @@ urlpatterns = [
         'employees/<int:employee_id>/clock-out/',
         views.ClockOutView.as_view(),
         name='clock-out',
+    ),
+]
+
+
+urlpatterns = [
+    path(
+        'clients/<slug:client_slug>/',
+        include(client_detail_urls)
     ),
     path(
         'dashboard/',

--- a/timetracker/vms/views.py
+++ b/timetracker/vms/views.py
@@ -23,7 +23,8 @@ class ClockInView(LoginRequiredMixin, FormView):
 
         kwargs['employee'] = get_object_or_404(
             models.Employee,
-            pk=self.kwargs.get('employee_id'),
+            supervisor__client__slug=self.kwargs.get('client_slug'),
+            employee_id=self.kwargs.get('employee_id'),
             user=self.request.user,
         )
 
@@ -64,7 +65,8 @@ class ClockOutView(LoginRequiredMixin, FormView):
 
         kwargs['employee'] = get_object_or_404(
             models.Employee,
-            pk=self.kwargs.get('employee_id'),
+            supervisor__client__slug=self.kwargs.get('client_slug'),
+            employee_id=self.kwargs.get('employee_id'),
             user=self.request.user,
         )
 


### PR DESCRIPTION
The time tracking URLs now use the client slug and employee ID to identify the employee being clocked in or out.