### PR TITLE
Preserve login redirect on signup page.

### DIFF
--- a/timetracker/account/templates/registration/login.html
+++ b/timetracker/account/templates/registration/login.html
@@ -7,7 +7,7 @@
   <div class="col-sm-12 col-md-8 offset-md-2 col-lg-6 offset-lg-3">
     <h1 class="border-bottom mb-4 pb-1">Log In</h1>
     <p class="alert alert-info">
-      Don't have an account? <a href="{% url 'account:signup' %}">Sign up</a> to create one.
+      Don't have an account? <a href="{% url 'account:signup' %}{% if 'next' in request.GET %}?next={{ request.GET.next | urlencode }}{% endif %}">Sign up</a> to create one.
     </p>
     <form method="post">
       {{ form|crispy }}

--- a/timetracker/account/test/views/test_sign_up_view.py
+++ b/timetracker/account/test/views/test_sign_up_view.py
@@ -31,3 +31,23 @@ def test_sign_up(client, db):
     # A side effect of signing up should be that the user is now logged
     # in.
     assert get_user(client) == user
+
+
+def test_sign_up_with_redirect(client, db):
+    """
+    If there is a 'next' parameter in the URL, it should be used to
+    redirect the user after they sign up.
+    """
+    data = {
+        'name': 'John Smith',
+        'password1': 'c0mplexpassw0rd',
+        'password2': 'c0mplexpassw0rd',
+        'username': 'johnsmith',
+    }
+
+    next_url = '/'
+    url = f'{URL}?next={next_url}'
+    response = client.post(url, data)
+
+    assert response.status_code == 302
+    assert response.url == next_url

--- a/timetracker/account/views.py
+++ b/timetracker/account/views.py
@@ -2,7 +2,7 @@ import logging
 
 from django.contrib.auth import authenticate, login
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.shortcuts import redirect
+from django.urls import reverse
 from django.views import generic
 from django.views.generic import TemplateView
 
@@ -47,4 +47,18 @@ class SignUpView(generic.FormView):
 
         logger.info('Registered new user %r', user)
 
-        return redirect('account:profile')
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        """
+        Get the URL that the user is redirected to after submitting the
+        form.
+
+        Returns:
+            The URL provided in the 'next' parameter or the URL of the
+            user's profile if no redirect URL is provided.
+        """
+        return self.request.GET.get(
+            'next',
+            reverse('account:profile'),
+        )


### PR DESCRIPTION
If the user navigates to the signup page from the login page with a redirect set, the redirect is preserved after the signup is complete.

Closes #25 