### PR TITLE
admin page bugfix - adding no supervisor will not break the employee …

### DIFF
--- a/timetracker/vms/admin.py
+++ b/timetracker/vms/admin.py
@@ -85,7 +85,10 @@ class EmployeeAdmin(admin.ModelAdmin):
     )
 
     def supervisor_name(self, obj):
-        return obj.supervisor.user.name
+        if obj.supervisor:
+            return obj.supervisor.user.name
+        else:
+            return "-"
     supervisor_name.admin_order_field = 'supervisor__user__name'
 
 


### PR DESCRIPTION
The admin page was breaking if no supervisor is selected.  this hopefully fixes it.
it will still break if no client is provided however