### PR TITLE
Fix issue with employee detail view.

### DIFF
--- a/.idea/timetracker-web.iml
+++ b/.idea/timetracker-web.iml
@@ -19,12 +19,10 @@
     </content>
     <orderEntry type="jdk" jdkName="Pipenv (timetracker-web)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Pipenv (timetracker-web) interpreter library" level="application" />
     <orderEntry type="library" name="jquery-3.2.1.slim" level="application" />
     <orderEntry type="library" name="popper" level="application" />
     <orderEntry type="library" name="bootstrap" level="application" />
     <orderEntry type="library" name="countUp" level="application" />
-    <orderEntry type="library" name="jquery-3.3.1.slim" level="application" />
   </component>
   <component name="PackageRequirementsSettings">
     <option name="requirementsPath" value="" />

--- a/timetracker/vms/test/views/test_employee_detail_view.py
+++ b/timetracker/vms/test/views/test_employee_detail_view.py
@@ -104,6 +104,40 @@ def test_get_object_self(employee_factory, request_factory):
     assert view.get_object() == employee
 
 
+def test_get_object_self_and_multiple_admins(
+    client_admin_factory,
+    employee_factory,
+    request_factory,
+):
+    """
+    The employee should be able to fetch their own record if their are
+    multiple admins for the client company.
+
+    Regression test for GH-113.
+
+    https://github.com/comp523-jarvis/timetracker-web/issues/113
+    """
+    admin = client_admin_factory()
+    client_admin_factory(client=admin.client)
+    employee = employee_factory(
+        client=admin.client,
+        user=admin.user,
+    )
+
+    url = employee.get_absolute_url()
+    request = request_factory.get(url)
+    request.user = employee.user
+
+    view = views.EmployeeDetailView()
+    view.kwargs = {
+        'client_slug': employee.client.slug,
+        'employee_id': employee.employee_id,
+    }
+    view.request = request
+
+    assert view.get_object() == employee
+
+
 def test_get_object_staffer(
     employee_factory,
     request_factory,

--- a/timetracker/vms/views.py
+++ b/timetracker/vms/views.py
@@ -535,9 +535,12 @@ class EmployeeDetailView(
         is_staffer = Q(staffing_agency__admin__user=self.request.user)
         is_supervisor = Q(client__admin__user=self.request.user)
 
-        return get_object_or_404(
-            models.Employee,
+        employees = models.Employee.objects.filter(
             is_self | is_staffer | is_supervisor,
+        ).distinct()
+
+        return get_object_or_404(
+            employees,
             client__slug=self.kwargs.get('client_slug'),
             employee_id=self.kwargs.get('employee_id'),
         )


### PR DESCRIPTION
In the case when the client company for an employee had multiple admins, the employee detail view had duplicate rows when fetching the employee record. We now eliminate duplicates when fetching the employee. This bug was introduced in the permission checks that addressed #105, specifically by PR #108.